### PR TITLE
Handle a curly bracket correctly.

### DIFF
--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -120,7 +120,7 @@ module FlavourSaver
       :EXPRE
     end
 
-    rule /[^{{]+/, :default do |output|
+    rule /.*?(?={{|\z)/m, :default do |output|
       [ :OUT, output ]
     end
   end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -175,5 +175,13 @@ describe FlavourSaver::Lexer do
         subject.map(&:type).should == [:OUT,:EOS]
       end
     end
+
+    describe 'Single curly bracket' do
+      subject { FlavourSaver::Lexer.lex "{" }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:OUT,:EOS]
+      end
+    end
   end
 end


### PR DESCRIPTION
before:

```
>> FS.evaluate '{', Object.new
RLTK::LexingError: Unable to match string with any of the given rules: 
        from /home/ursm/.rbenv/versions/1.9.3-p362/lib/ruby/gems/1.9.1/gems/rltk-2.2.1/lib/rltk/lexer.rb:141:in `lex'
        from /home/ursm/src/FlavourSaver/lib/flavour_saver.rb:40:in `lex'
        from /home/ursm/src/FlavourSaver/lib/flavour_saver.rb:48:in `evaluate'
        from (irb):1
```

after:

```
>> FS.evaluate '{', Object.new
=> "{"
```
