### PR TITLE
Fixes CVE-2013-4492 XSS vulnerability in the i18n gem before 0.6.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,12 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.0.0)
-      i18n (~> 0.6, >= 0.6.4)
+    activesupport (4.0.13)
+      i18n (~> 0.6, >= 0.6.9)
       minitest (~> 4.2)
       multi_json (~> 1.3)
       thread_safe (~> 0.1)
       tzinfo (~> 0.3.37)
-    atomic (1.1.14)
     coderay (1.0.9)
     diff-lcs (1.2.4)
     ffi (1.9.0)
@@ -31,7 +30,7 @@ GEM
     guard-rspec (3.1.0)
       guard (>= 1.8)
       rspec (~> 2.13)
-    i18n (0.6.5)
+    i18n (0.7.0)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9)
@@ -39,7 +38,7 @@ GEM
     lumberjack (1.0.4)
     method_source (0.8.2)
     minitest (4.7.5)
-    multi_json (1.8.0)
+    multi_json (1.10.1)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -62,16 +61,15 @@ GEM
     rspec-mocks (2.14.3)
     slop (3.4.6)
     thor (0.18.1)
-    thread_safe (0.1.3)
-      atomic
+    thread_safe (0.3.4)
     tilt (1.4.1)
-    tzinfo (0.3.37)
+    tzinfo (0.3.42)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport
+  activesupport (~> 4.0.2)
   flavour_saver!
   guard-bundler
   guard-rspec

--- a/flavour_saver.gemspec
+++ b/flavour_saver.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'rspec-mocks'
   gem.add_development_dependency 'rspec-expectations'
   gem.add_development_dependency 'guard-bundler'
-  gem.add_development_dependency 'activesupport'
+  gem.add_development_dependency 'activesupport', '~> 4.0.2'
 
   gem.add_dependency 'rltk', '~> 2.2.0'
   gem.add_dependency 'tilt'


### PR DESCRIPTION
Upgrade to a version of activesupport that has been patched against this vulnerability.

This will also clear the warning on Gemnasium
https://gemnasium.com/jamesotron/FlavourSaver

cc: @jamesotron 