### PR TITLE
Allows strings as a partial name

### DIFF
--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -56,6 +56,7 @@ module FlavourSaver
     end
 
     production(:partial) do
+      clause('EXPRST WHITE? GT WHITE? STRING WHITE? EXPRE') { |_,_,_,_,e,_,_| PartialNode.new(e,[]) }
       clause('EXPRST WHITE? GT WHITE? IDENT WHITE? EXPRE') { |_,_,_,_,e,_,_| PartialNode.new(e,[]) }
       clause('EXPRST WHITE? GT WHITE? IDENT WHITE? call WHITE? EXPRE') { |_,_,_,_,e0,_,e1,_,_| PartialNode.new(e0,e1,nil) }
       clause('EXPRST WHITE? GT WHITE? IDENT WHITE? lit WHITE? EXPRE') { |_,_,_,_,e0,_,e1,_,_| PartialNode.new(e0,[],e1) }

--- a/spec/acceptance/handlebars_qunit_spec.rb
+++ b/spec/acceptance/handlebars_qunit_spec.rb
@@ -748,6 +748,18 @@ describe FlavourSaver do
     end
   end
 
+  describe 'partials with string paths' do
+    let(:template) { "Dudes: {{> \"dude/man\"}}" }
+    before do
+      FS.register_partial("dude/man", "{{name}}")
+    end
+    example do
+      context.stub(:name).and_return('Jeepers')
+      context.stub(:another_dude).and_return('Creepers')
+      subject.should == "Dudes: Jeepers"
+    end
+  end
+
   describe 'string literal parameters' do
 
     describe 'simple literals work' do


### PR DESCRIPTION
Allows partial's to contain a string rather than just only an identifier...

```html
{{> "path/to/partial"}}
```