### PR TITLE
fixes circular arg ref on ruby 2.2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ rvm:
   - 1.9.3
   - 2.0.0
   - 2.1.5
+  - 2.2.1
+  - 2.2.2
   - jruby-19mode
   - rbx-19mode
 script: 'bundle exec rspec'

--- a/lib/flavour_saver/runtime.rb
+++ b/lib/flavour_saver/runtime.rb
@@ -115,7 +115,7 @@ module FlavourSaver
       end
     end
 
-    def evaluate_call(call, context=context, &block)
+    def evaluate_call(call, context=self.context, &block)
       context = Helpers.decorate_with(context,@helpers,@locals) unless context.is_a? Helpers::Decorator
       case call
       when ParentCallNode


### PR DESCRIPTION
Six specs fail on Ruby 2.2.1 and 2.2.2. All specs pass w/ this fix.