### PR TITLE
fixed mixed args issue and updated specs

### DIFF
--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -121,7 +121,7 @@ module FlavourSaver
 
     production('arguments') do
       clause('argument_list') { |e| e }
-      clause('argument_list hash') { |e0,e1| e0 + [e1] }
+      clause('argument_list WHITE hash') { |e0,_,e1| e0 + [e1] }
       clause('hash') { |e| [e] }
     end
 

--- a/spec/lib/flavour_saver/parser_spec.rb
+++ b/spec/lib/flavour_saver/parser_spec.rb
@@ -41,7 +41,7 @@ describe FlavourSaver::Parser do
       items.first.method.first.name.should == 'foo'
       items.first.method.first.arguments.should be_empty
     end
-   end
+  end
 
   describe '{{foo.bar}}' do
     subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{foo.bar}}')) }
@@ -296,7 +296,6 @@ describe FlavourSaver::Parser do
       -> { subject }.should_not raise_error
     end
   end
-
   describe '' do
     subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('')) }
 
@@ -304,5 +303,15 @@ describe FlavourSaver::Parser do
       items.should be_empty
     end
   end
-
+  describe '{{foo "bar" fred="wilma"}}' do
+    subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{foo "bar" fred="wilma"}}')) }
+    it 'calls the method "foo" with the "bar" and {:fred => "wilma"} as arguments' do
+      items.first.method.first.should be_a(FlavourSaver::CallNode)
+      items.first.method.first.name.should == 'foo'
+      items.first.method.first.arguments.first.should be_a(FlavourSaver::StringNode)
+      items.first.method.first.arguments.first.value.should == 'bar'
+      items.first.method.first.arguments.last.should be_a(Hash)
+      items.first.method.first.arguments.last.should == { :fred => FlavourSaver::StringNode.new('wilma') }
+    end
+  end
 end


### PR DESCRIPTION
This should allow mixed arguments in methods such as {{foo "bar" fred="wilma"}}. I have added the relevant spec but haven't tested all/extreme cases. All specs are passing 100%.