### PR TITLE
adds raw blocks to prevent parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Currently supported:
     - Block expressions with inverse blocks
     - Inverse blocks
   - Partials
+  - Raw content (`{{{{raw}}}} not parsed or validated {{{{/raw}}}}`)
 
 ## Helpers
 

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -3,6 +3,21 @@ require 'rltk'
 module FlavourSaver
   class Lexer < RLTK::Lexer
 
+     # seems to have problem with hash symbol in regex
+    rule /\{\{\{\{raw\}\}\}\}/, :default do
+      push_state :raw
+      :RAWSTART
+    end
+
+    rule /.*?(?=\{\{\{\{\/raw\}\}\}\})/m, :raw do |str|
+      [ :RAWSTRING, str ]
+    end
+
+    rule /\{\{\{\{\/raw\}\}\}\}/, :raw do
+      pop_state
+      :RAWEND
+    end
+
     rule /{{{/, :default do
       push_state :expression
       :TEXPRST

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -39,12 +39,17 @@ module FlavourSaver
     end
 
     production(:template_item) do
-      clause('output') { |e| e }
+      clause('raw_bl')     { |e| e }
+      clause('output')     { |e| e }
       clause('expression') { |e| e }
     end
 
     production(:output) do
       clause('OUT') { |o| OutputNode.new(o) }
+    end
+
+    production(:raw_bl) do
+      clause('RAWSTART RAWSTRING RAWEND') { |_,e,_| OutputNode.new(e) }
     end
 
     production(:expression) do

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "0.3.6"
+  VERSION = "0.3.7"
 end

--- a/spec/acceptance/raw_block_spec.rb
+++ b/spec/acceptance/raw_block_spec.rb
@@ -1,0 +1,12 @@
+require 'tilt'
+require 'flavour_saver'
+
+describe 'Fixture: raw.hbs' do
+  subject { Tilt.new(template).render(context).gsub(/[\s\r\n]+/, ' ').strip }
+  let(:template) { File.expand_path('../../fixtures/raw.hbs', __FILE__) }
+  let(:context)  { double(:context) }
+
+  it 'renders correctly' do
+    subject.should == "{{=if brokensyntax}"
+  end
+end

--- a/spec/fixtures/raw.hbs
+++ b/spec/fixtures/raw.hbs
@@ -1,0 +1,3 @@
+{{{{raw}}}}
+{{=if brokensyntax}
+{{{{/raw}}}}


### PR DESCRIPTION
Hello,

This PR adds the ability to wrap content in `{{{{raw}}}}` blocks and not have it parse ot try to render it. 

I've spent a few days hammering away on this, and it's probably the longest its ever taken me to write ~35 LOC. I was/am woefully ignorant of RLTK and of the codebase, so I apologize if this is not the absolute best way to go about it; I spent a lot of time fighting RLTK errors, and my own ignorance. 

So, this mostly works. the quad brackets isn't a real block type, and I can't for the life of me get it to work with a hash like `{{{{#raw}}}}` despite every incantation I can think of. 

Happy to discuss and make any changes to get this out the door. 