### PR TITLE
adds subexpression support

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ Currently supported:
     - Inverse blocks
   - Partials
   - Raw content (`{{{{raw}}}} not parsed or validated {{{{/raw}}}}`)
+  - Subexpressions (`{{sum 1 (sum 1 1)}}` returns `3`)
 
 ## Helpers
 
@@ -246,6 +247,22 @@ Which could be used like so:
 {{else}}
   {{person.name}} is male.
 {{/isFemale}}
+```
+
+### Subexpressions
+
+You can use a subexpression as any value for a helper, and it will be executed before it is ran. You can also nest them, and use them in assignment of variables. 
+
+Below are some examples, utilizing a "sum" helper than adds together two numbers.
+
+```
+{{sum (sum 5 10) (sum 2 (sum 1 4))}}
+#=> 22
+
+{{#if (sum 1 2) > 2}}its more{{/if}}
+#=> its more
+
+{{#student_heights size=(sum boys girls)}}
 ```
 
 ### Using Partials

--- a/README.md
+++ b/README.md
@@ -265,6 +265,19 @@ Below are some examples, utilizing a "sum" helper than adds together two numbers
 {{#student_heights size=(sum boys girls)}}
 ```
 
+### Raw Content
+
+Sometimes you don't want a section of content to be evaluted as handlebars, such as when you want to display it in a page that renders with handlebars. FlavourSaver offers a `raw` helper, that will allow you to pass anything through wrapped in those elements, and it will not be evaluated. 
+
+```
+{{{{raw}}}}
+{{if} this tries to parse, it will break on syntax
+{{{{/raw}}}}
+=> {{if} this tries to parse, it will break on syntax
+```
+
+Its important to note that while this looks like a block helper, it is not in practice. This is why you must omit the use of a `#` when writing it. 
+
 ### Using Partials
 
 Handlebars allows you to register a partial either as a function or a string template with

--- a/lib/flavour_saver/lexer.rb
+++ b/lib/flavour_saver/lexer.rb
@@ -86,6 +86,14 @@ module FlavourSaver
       :DOT
     end
 
+    rule /\(/, :expression do
+      :OPAR
+    end
+
+    rule /\)/, :expression do
+      :CPAR
+    end
+
     rule /\=/, :expression do
       :EQ
     end

--- a/lib/flavour_saver/parser.rb
+++ b/lib/flavour_saver/parser.rb
@@ -86,6 +86,10 @@ module FlavourSaver
       clause('EXPRST expression_contents EXPRE') { |_,e,_| e }
     end
 
+    production(:subexpr) do
+      clause('OPAR expression_contents CPAR') { |_,e,_| e }
+    end
+
     production(:expr_comment) do
       clause('EXPRST BANG COMMENT EXPRE') { |_,_,e,_| e }
     end
@@ -130,7 +134,7 @@ module FlavourSaver
       clause('hash') { |e| [e] }
     end
 
-    nonempty_list(:argument_list, [:object_path,:lit], :WHITE)
+    nonempty_list(:argument_list, [:object_path,:lit, :subexpr], :WHITE)
 
     production(:lit) do
       clause('string') { |e| e }
@@ -157,6 +161,7 @@ module FlavourSaver
     end
 
     production(:hash_item) do
+      clause('IDENT EQ subexpr') { |e0,_,e1| { e0.to_sym => e1 } }
       clause('IDENT EQ string') { |e0,_,e1| { e0.to_sym => e1 } }
       clause('IDENT EQ number') { |e0,_,e1| { e0.to_sym => e1 } }
       clause('IDENT EQ object_path') { |e0,_,e1| { e0.to_sym => e1 } }

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "0.3.7"
+  VERSION = "0.3.8"
 end

--- a/spec/acceptance/subexpression_spec.rb
+++ b/spec/acceptance/subexpression_spec.rb
@@ -1,0 +1,38 @@
+require 'tilt'
+require 'flavour_saver'
+
+describe 'Subexpressions' do
+
+  subject { Tilt['handlebars'].new{ template }.render(context).gsub(/[\s\r\n]+/, ' ').strip }
+  
+  let(:context)  { double(:context) }
+  before(:all) do
+    FlavourSaver.register_helper(:sum) { |a,b| a + b}
+  end
+  context "simple subexpression" do
+    let(:template) { "{{sum 1 (sum 1 1)}}" }
+    specify{subject.should == "3"}
+  end
+
+  context "nested subexpressions" do
+    let(:template) { "{{sum 1 (sum 1 (sum 1 1))}}" }
+    specify{subject.should == "4"}
+  end
+
+  context "subexpression as argument" do
+    before {FlavourSaver.register_helper(:cents) { |a| a[:total] + 10}}
+    let(:template) { "{{cents total=(sum 1 1)}}" }
+    specify{subject.should == "12"}
+  end
+
+  context "subexpression in block" do
+    before {FlavourSaver.register_helper(:repeat) do |a, &block| 
+      s = ''
+      a.times {s += block.call.contents}
+      s
+    end}
+    let(:template) { "{{#repeat (sum 1 2)}}*{{/repeat}}" }
+    specify{subject.should == "***"}
+  end
+  
+end

--- a/spec/lib/flavour_saver/lexer_spec.rb
+++ b/spec/lib/flavour_saver/lexer_spec.rb
@@ -49,6 +49,18 @@ describe FlavourSaver::Lexer do
         end
       end
 
+      describe '{{foo (bar "baz")}}' do
+        subject { FlavourSaver::Lexer.lex "{{foo (bar 'baz')}}" }
+
+        it 'has tokens in the correct order' do
+          subject.map(&:type).should ==  [ :EXPRST, :IDENT, :WHITE, :OPAR, :IDENT, :WHITE, :S_STRING, :CPAR, :EXPRE, :EOS ]
+        end
+
+        it 'has values in the correct order' do
+          subject.map(&:value).compact.should == [ 'foo', 'bar', 'baz' ]
+        end
+      end
+
       describe '{{foo bar="baz" hello="goodbye"}}' do
         subject { FlavourSaver::Lexer.lex '{{foo bar="baz" hello="goodbye"}}' }
 
@@ -60,6 +72,18 @@ describe FlavourSaver::Lexer do
           subject.map(&:value).compact.should == [ 'foo', 'bar', 'baz', 'hello', 'goodbye' ]
         end
 
+      end
+    end
+
+    describe '{{foo bar=(baz qux)}}' do
+      subject { FlavourSaver::Lexer.lex '{{foo bar=(baz qux)}}' }
+
+      it 'has tokens in the correct order' do
+        subject.map(&:type).should == [:EXPRST, :IDENT, :WHITE, :IDENT, :EQ, :OPAR, :IDENT, :WHITE, :IDENT, :CPAR, :EXPRE, :EOS]
+      end
+
+      it 'has values in the correct order' do
+        subject.map(&:value).compact.should == [ 'foo', 'bar', 'baz', 'qux' ]
       end
     end
 

--- a/spec/lib/flavour_saver/parser_spec.rb
+++ b/spec/lib/flavour_saver/parser_spec.rb
@@ -143,6 +143,28 @@ describe FlavourSaver::Parser do
     end
   end
 
+  describe '{{foo (bar "baz") }}' do
+    subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{foo (bar "baz") }}')) }
+
+    it 'calls the method "foo"' do
+      items.first.method.should be_one
+      items.first.method.first.should be_a(FlavourSaver::CallNode)
+      items.first.method.first.name.should == 'foo'
+    end
+
+    describe 'with arguments' do
+      subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{foo (bar "baz") }}')).items.first.method.first.arguments }
+
+      describe '[0]' do
+        it 'is a subexpression' do
+          subject.first.first.should be_a(FlavourSaver::CallNode)
+          subject.first.first.name.should == 'bar'
+        end
+      end
+
+    end
+  end
+
   describe '{{foo bar="baz"}}' do
     subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{foo bar="baz"}}')) }
 
@@ -151,6 +173,17 @@ describe FlavourSaver::Parser do
       items.first.method.first.name.should == 'foo'
       items.first.method.first.arguments.first.should be_a(Hash)
       items.first.method.first.arguments.first.should == { :bar => FlavourSaver::StringNode.new('baz') }
+    end
+  end
+
+  describe '{{foo bar=(baz "qux")}}' do
+    subject { FlavourSaver::Parser.parse(FlavourSaver::Lexer.lex('{{foo bar=(baz "qux")}}')) }
+
+    it 'calls the method "foo" with the hash {:bar => (baz "qux")} as arguments' do
+      items.first.method.first.should be_a(FlavourSaver::CallNode)
+      items.first.method.first.name.should == 'foo'
+      items.first.method.first.arguments.first.should be_a(Hash)
+      items.first.method.first.arguments.first[:bar].first.should be_a(FlavourSaver::CallNode)
     end
   end
 

--- a/spec/lib/flavour_saver/runtime_spec.rb
+++ b/spec/lib/flavour_saver/runtime_spec.rb
@@ -110,6 +110,17 @@ describe FlavourSaver::Runtime do
       end
     end
 
+    describe 'when called with a subexpression' do
+      let(:template) { "{{hello (there world)}}" }
+
+      it 'calls there & world first, then passes off to hello' do
+        context.should_receive(:world).and_return('world')
+        context.should_receive(:there).with('world').and_return('there world')
+        context.should_receive(:hello).with('there world').and_return('hello there world')
+        subject.evaluate_expression(expr).should == 'hello there world'
+      end
+    end
+
     describe 'when called with an object path' do
       let(:template) { "{{hello.world}}" }
 


### PR DESCRIPTION
This PR adds support for subexpressions. Works for simple helpers, block helpers, nested, and as hash parameters. 

```
{{sum 1 (sum 1 (sum 1 1))}}
#=> 4
```

Let me know if there's anything this needs to go out the door!

also snuck in some docs for raw blocks, added previously