### PR TITLE
Prepare v4.0.0 release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v6
     - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
+        ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0']
 
     steps:
     - uses: actions/checkout@v2
@@ -31,10 +31,10 @@ jobs:
     needs: [test]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Ruby 2.7
+    - name: Set up Ruby 3.1
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        ruby-version: 3.1
     - name: Publish to RubyGems
       run: |
         mkdir -p $HOME/.gem

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 4.0.0
+
+### Added
+
+* Added Ruby 4.0 to the test matrix
+
+### Removed
+
+* Dropped support for Ruby 2.7 and 3.0
+
 ## 3.0.0
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 8.0)
+  activesupport (~> 7.2.0)
   flavour_saver!
   rake
   rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,39 +1,37 @@
 PATH
   remote: .
   specs:
-    flavour_saver (3.0.0)
+    flavour_saver (4.0.0)
       rltk (< 3.0)
       tilt (~> 2.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (7.1.5.1)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
+      concurrent-ruby (~> 1.0, >= 1.3.1)
       connection_pool (>= 2.2.5)
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
-      mutex_m
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
-      tzinfo (~> 2.0)
-    base64 (0.2.0)
-    benchmark (0.4.0)
-    bigdecimal (3.1.9)
-    concurrent-ruby (1.3.5)
-    connection_pool (2.5.0)
+      tzinfo (~> 2.0, >= 2.0.5)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.1.0)
+    concurrent-ruby (1.3.6)
+    connection_pool (2.5.5)
     diff-lcs (1.5.1)
-    drb (2.2.1)
-    ffi (1.17.1)
-    i18n (1.14.7)
+    drb (2.2.3)
+    ffi (1.17.4)
+    i18n (1.14.8)
       concurrent-ruby (~> 1.0)
-    logger (1.6.5)
-    minitest (5.25.4)
-    mutex_m (0.3.0)
+    logger (1.7.0)
+    minitest (5.27.0)
     rake (13.2.1)
     rltk (2.2.1)
       ffi (>= 1.0.0)
@@ -50,8 +48,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.13.0)
     rspec-support (3.13.2)
-    securerandom (0.3.2)
-    tilt (2.6.0)
+    securerandom (0.4.1)
+    tilt (2.7.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
@@ -59,7 +57,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activesupport (< 7.2)
+  activesupport (< 8.0)
   flavour_saver!
   rake
   rspec

--- a/flavour_saver.gemspec
+++ b/flavour_saver.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "activesupport", "< 8.0"
+  gem.add_development_dependency "activesupport", "~> 7.2.0"
 
   gem.add_dependency "rltk", "< 3.0"
   gem.add_dependency "tilt", "~> 2.6"

--- a/flavour_saver.gemspec
+++ b/flavour_saver.gemspec
@@ -22,11 +22,11 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = FlavourSaver::VERSION
 
-  gem.required_ruby_version = ">= 2.7.0"
+  gem.required_ruby_version = ">= 3.1.0"
 
   gem.add_development_dependency "rake"
   gem.add_development_dependency "rspec"
-  gem.add_development_dependency "activesupport", "< 7.2"
+  gem.add_development_dependency "activesupport", "< 8.0"
 
   gem.add_dependency "rltk", "< 3.0"
   gem.add_dependency "tilt", "~> 2.6"

--- a/lib/flavour_saver/version.rb
+++ b/lib/flavour_saver/version.rb
@@ -1,3 +1,3 @@
 module FlavourSaver
-  VERSION = "3.0.0"
+  VERSION = "4.0.0"
 end


### PR DESCRIPTION
### What

* Drop support for Ruby 2.7 and 3.0
* Add support for Ruby 4.0
* Minimum Ruby version is now 3.1
* Bump ActiveSupport dev dependency to 7.2.x